### PR TITLE
Replace Makefile with atmos.yaml

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -51,8 +51,7 @@ references:
     description: 'Automatically creates "Long Term Support (LTS)" release branches when new releases are published'
     url: "https://en.wikipedia.org/wiki/Test_harness"
 
-include:
-  - "docs/github-action.md"
+include: []
 
 contributors:
   - name: "Zinovii Dmytriv"


### PR DESCRIPTION
## what
- Remove `Makefile`
- Add `atmos.yaml`

## why
- Replace `build-harness` with `atmos` for readme genration

## References
* DEV-3229 Migrate from build-harness to atmos
